### PR TITLE
Fix: regular expression to parse ping output message

### DIFF
--- a/lib/topology_lib_ping/library.py
+++ b/lib/topology_lib_ping/library.py
@@ -30,6 +30,7 @@ from ipaddress import ip_address
 PING_RE = (
     r'^(?P<transmitted>\d+) packets transmitted, '
     r'(?P<received>\d+) received,'
+    r'( \+(?P<duplicates>\d+) duplicates,)?'
     r'( \+(?P<errors>\d+) errors,)? '
     r'(?P<loss_pc>\d+)% packet loss, '
     r'time (?P<time_ms>\d+)ms$'


### PR DESCRIPTION
While ping command was capture, the parser function was using a wrong regular expresation. the fix add the duplicate token 
